### PR TITLE
コメント欄の装飾

### DIFF
--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -42,6 +42,13 @@ header {
   min-height: 150px;
   padding: 0 30px 0;
   position: relative;
+  &.comments {
+    background-color: #7c7c;
+    border: none;
+    padding-top: 5px;
+    font-size: 12px;
+    min-height: 30px;
+  }
   &__text {
     padding-bottom: 40px;
   }
@@ -75,5 +82,20 @@ header {
     }
   }
 }
+
+form#new_comment {
+  margin: 0 auto;
+  width: 800px;
+  height: 100px;
+  #comment_comment {
+    width: 800px;
+    height: 50px;
+    resize: none;
+  }
+  input[type="submit"] {
+    float: right;
+  }
+}
+
 
 

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -2,8 +2,8 @@ class CommentsController < ApplicationController
   def create
     @comment = Comment.create(comment_params)
     # @comment = Comment.create(comment: "comment", user_id: 1, message_id: 17)
-    redirect_to root_path
-    # redirect_to message_path(@comment.messages.id)
+    # redirect_to root_path
+    redirect_to message_path(@comment.message_id)
   end
 
   private

--- a/app/views/messages/_comments.haml
+++ b/app/views/messages/_comments.haml
@@ -1,3 +1,3 @@
-.body
+.body.comments
   %p.body__text
     = comment.comment

--- a/app/views/messages/show.haml
+++ b/app/views/messages/show.haml
@@ -1,10 +1,11 @@
 = render "messages", message: @message
 
-- @comments.each do |comment|
-  = render "comments", comment: comment
-
 - if current_user
   = form_for [@message, @comment] do |f|
     = f.text_area :comment
     %br
     = f.submit "Send"
+
+- @comments.each do |comment|
+  = render "comments", comment: comment
+


### PR DESCRIPTION
#WHAT
コメント表示の装飾変更をし明確にする
#WHY
メッセージとコメントの表示が同一で分かりにくい為